### PR TITLE
move IDomainEventHandler<>'s Handlers implementation into Application

### DIFF
--- a/SnackMachineApp.Application/Management/BalanceChangedEventHandler.cs
+++ b/SnackMachineApp.Application/Management/BalanceChangedEventHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using SnackMachineApp.Domain.Atms;
 using SnackMachineApp.Domain.Management;
-using SnackMachineApp.Domain.Seedwork;
 using SnackMachineApp.Infrastructure;
 using System.Threading.Tasks;
 
@@ -14,7 +13,7 @@ namespace SnackMachineApp.Application.Management
             Guard.Against.Null(domainEvent, nameof(domainEvent));
 
             var repository = ObjectFactory.Instance.Resolve<IHeadOfficeRepository>();
-            HeadOffice headOffice = HeadOfficeInstance.Instance;
+            var headOffice = HeadOfficeInstance.Instance;
             headOffice.ChangeBalance(domainEvent.Delta);
             repository.Save(headOffice);
 

--- a/SnackMachineApp.Domain.Tests/AutofacTest.cs
+++ b/SnackMachineApp.Domain.Tests/AutofacTest.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
+using SnackMachineApp.Application.Management;
 using SnackMachineApp.Domain.Atms;
-using SnackMachineApp.Domain.Core.Interfaces;
 using SnackMachineApp.Domain.SnackMachines;
-using SnackMachineApp.Domain.Utils;
+using SnackMachineApp.Infrastructure;
+using SnackMachineApp.Infrastructure.Data;
 using System;
 using Xunit;
 

--- a/SnackMachineApp.Domain.Tests/RepositoryTest.cs
+++ b/SnackMachineApp.Domain.Tests/RepositoryTest.cs
@@ -1,7 +1,6 @@
 ﻿using SnackMachineApp.Domain.SnackMachines;
-using SnackMachineApp.Domain.Utils;
+using SnackMachineApp.Infrastructure;
 using System;
-using System.Configuration;
 using Xunit;
 using static SnackMachineApp.Domain.SharedKernel.Money;
 
@@ -11,7 +10,7 @@ namespace SnackMachineApp.Domain.Tests
     {
         public RepositoryTest()
         {
-            ObjectFactory.Instance.GetType();//.Init(ConfigurationManager.ConnectionStrings["AppCnn"].ConnectionString);
+            ObjectFactory.Instance.GetType();
         }
         public void Dispose()
         {

--- a/SnackMachineApp.Domain.Tests/SnackMachineApp.Domain.Tests.csproj
+++ b/SnackMachineApp.Domain.Tests/SnackMachineApp.Domain.Tests.csproj
@@ -34,7 +34,9 @@
   
   
   <ItemGroup>
+    <ProjectReference Include="..\SnackMachineApp.Application\SnackMachineApp.Application.csproj" />
     <ProjectReference Include="..\SnackMachineApp.Domain\SnackMachineApp.Domain.csproj" />
+    <ProjectReference Include="..\SnackMachineApp.Infrastructure\SnackMachineApp.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SnackMachineApp.Domain/Seedwork/IDomainEventHandler.cs
+++ b/SnackMachineApp.Domain/Seedwork/IDomainEventHandler.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace SnackMachineApp.Domain.Seedwork
-{
-    public interface IDomainEventHandler<in T> where T : IDomainEvent
-    {
-        Task Handle(T domainEvent);
-    }
-}

--- a/SnackMachineApp.Infrastructure/DomainEventDispatcher.cs
+++ b/SnackMachineApp.Infrastructure/DomainEventDispatcher.cs
@@ -1,36 +1,25 @@
 ﻿using SnackMachineApp.Domain.Seedwork;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace SnackMachineApp.Infrastructure
 {
     internal class DomainEventDispatcher : IDomainEventDispatcher
     {
-        private static List<Type> _handlers;
-
-        static DomainEventDispatcher()
-        {
-            _handlers = Assembly.GetExecutingAssembly()
-                .GetTypes()
-                .Where(x => x.GetInterfaces().Any(y => y.IsGenericType && y.GetGenericTypeDefinition() == typeof(IDomainEventHandler<>)))
-                .ToList();
-        }
-
         public Task Dispatch(IDomainEvent domainEvent)
         {
-            foreach (Type handlerType in _handlers)
+            var _handlers = ObjectFactory.Instance.Resolve<IEnumerable<IDomainEventHandler>>();
+            foreach (var handler in _handlers)
             {
-                bool canHandleEvent = handlerType.GetInterfaces()
+                bool canHandleEvent = handler.GetType().GetInterfaces()
                     .Any(x => x.GenericTypeArguments[0] == domainEvent.GetType());
 
                 if (canHandleEvent)
                 {
-                    //TODO: possible to get through DI
-                    dynamic handler = Activator.CreateInstance(handlerType);
-                    handler.Handle((dynamic)domainEvent);
+                    //TODO: remove dynamic
+                    dynamic handler2 = handler;
+                    handler2.Handle((dynamic)domainEvent);
                 }
             }
 

--- a/SnackMachineApp.Infrastructure/IDomainEventHandler.cs
+++ b/SnackMachineApp.Infrastructure/IDomainEventHandler.cs
@@ -1,0 +1,14 @@
+﻿using SnackMachineApp.Domain.Seedwork;
+using System.Threading.Tasks;
+
+namespace SnackMachineApp.Infrastructure
+{
+    public interface IDomainEventHandler
+    {
+    }
+
+    public interface IDomainEventHandler<in T>: IDomainEventHandler where T : IDomainEvent
+    {
+        Task Handle(T domainEvent);
+    }
+}

--- a/SnackMachineApp.WinUI/autofac.json
+++ b/SnackMachineApp.WinUI/autofac.json
@@ -3,7 +3,7 @@
     { "type": "SnackMachineApp.Infrastructure.ObjectFactory+DbConnectionProviderRegistrationModule, SnackMachineApp.Infrastructure" },
     { "type": "SnackMachineApp.Infrastructure.ObjectFactory+NHibernateRegistrationModule, SnackMachineApp.Infrastructure" },
     { "type": "SnackMachineApp.Infrastructure.ObjectFactory+RepositoryRegistrationModule, SnackMachineApp.Infrastructure" },
-    { "type": "SnackMachineApp.Infrastructure.ObjectFactory+EventHandlersRegistrationModule, SnackMachineApp.Infrastructure" },
+    { "type": "SnackMachineApp.Infrastructure.ObjectFactory+DomainEventHandlersRegistrationModule, SnackMachineApp.Infrastructure" },
     { "type": "SnackMachineApp.Infrastructure.ObjectFactory+MediatorRegistrationModule, SnackMachineApp.Infrastructure" },
     { "type": "SnackMachineApp.Infrastructure.ObjectFactory+DecoratorsRegistrationModule, SnackMachineApp.Infrastructure" }
   ],


### PR DESCRIPTION
the implementation of IDomainEventHandler<> should be in Application layer due to dispatching to other external applications.
ref: [Where to place domain event handlers?](https://softwareengineering.stackexchange.com/questions/325996/ddd-where-to-place-domain-event-handlers)